### PR TITLE
fix: find nested targets

### DIFF
--- a/test/lib/java-wrapper.test.ts
+++ b/test/lib/java-wrapper.test.ts
@@ -22,7 +22,7 @@ test('classes per jar mapping is created', async () => {
 test('not target folder throw error', async () => {
   expect(
     getEntrypoints('some-bogus-folder-that-does-not-exist'),
-  ).rejects.toThrowError('Could not find target folder');
+  ).rejects.toThrowError('Could not find a target folder');
 });
 
 test('entrypoints are found correctly', async () => {


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Check for target directories recursively.




