### PR TITLE
feat: add timeout for call graph builder

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -5,23 +5,29 @@ import { getCallGraph } from './java-wrapper';
 import { Graph } from '@snyk/graphlib';
 import { timeIt, getMetrics, Metrics } from './metrics';
 
-export async function getCallGraphMvn(targetPath: string): Promise<Graph> {
+export async function getCallGraphMvn(
+  targetPath: string,
+  timeout?: number,
+): Promise<Graph> {
   const classPath = await timeIt('getMvnClassPath', () =>
     getClassPathFromMvn(targetPath),
   );
 
   return await timeIt('getCallGraph', () =>
-    getCallGraph(classPath, targetPath),
+    getCallGraph(classPath, targetPath, timeout),
   );
 }
 
-export async function getClassGraphGradle(targetPath: string): Promise<Graph> {
+export async function getClassGraphGradle(
+  targetPath: string,
+  timeout?: number,
+): Promise<Graph> {
   const classPath = await timeIt('getGradleClassPath', () =>
     getCallGraphGradle(targetPath),
   );
 
   return await timeIt('getCallGraph', () =>
-    getCallGraph(classPath, targetPath),
+    getCallGraph(classPath, targetPath, timeout),
   );
 }
 

--- a/lib/java-wrapper.ts
+++ b/lib/java-wrapper.ts
@@ -31,8 +31,12 @@ function getCallGraphGenCommandArgs(
 async function runJavaCommand(
   javaCommandArgs: string[],
   targetPath: string,
+  timeout?: number,
 ): Promise<string> {
-  return execute('java', javaCommandArgs, { cwd: targetPath });
+  return execute('java', javaCommandArgs, {
+    cwd: targetPath,
+    timeout: timeout,
+  });
 }
 
 export async function getEntrypoints(targetPath: string): Promise<string[]> {
@@ -78,6 +82,7 @@ export async function getClassPerJarMapping(
 export async function getCallGraph(
   classPath: string,
   targetPath: string,
+  timeout?: number,
 ): Promise<Graph> {
   const jarPath = await fetch(
     config.CALL_GRAPH_GENERATOR_URL,
@@ -98,7 +103,7 @@ export async function getCallGraph(
   );
   try {
     const javaOutput = await timeIt('generateCallGraph', () =>
-      runJavaCommand(callgraphGenCommandArgs, targetPath),
+      runJavaCommand(callgraphGenCommandArgs, targetPath, timeout),
     );
     const classPerJarMapping = await timeIt('mapClassesPerJar', () =>
       getClassPerJarMapping(classPath),

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -3,7 +3,10 @@ import * as childProcess from 'child_process';
 export function execute(
   command: string,
   args: string[],
-  options?: { cwd?: string },
+  options?: {
+    cwd?: string;
+    timeout?: number;
+  },
 ): Promise<string> {
   const spawnOptions: childProcess.SpawnOptions = { shell: true };
   if (options && options.cwd) {
@@ -15,6 +18,17 @@ export function execute(
     let stderr = '';
 
     const proc = childProcess.spawn(command, args, spawnOptions);
+
+    if (options?.timeout) {
+      const timeoutSeconds = options.timeout / 1000;
+      setTimeout(() => {
+        proc.kill();
+        reject(
+          `Timeout; It took longer than ${timeoutSeconds}s to generate the call graph.`,
+        );
+      }, options.timeout);
+    }
+
     proc.stdout.on('data', (data: Buffer) => {
       stdout = stdout + data;
     });


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add an option to kill the call graph generator Java process after a period. This is meant to give more control over the call graph generation process to CLI users.

- [Jira ticket FLOW-336](https://snyksec.atlassian.net/browse/FLOW-336)