### PR TITLE
fix: clear timeout when external process exits

### DIFF
--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -19,9 +19,10 @@ export function execute(
 
     const proc = childProcess.spawn(command, args, spawnOptions);
 
+    let timerId: NodeJS.Timer | null = null;
     if (options?.timeout) {
       const timeoutSeconds = options.timeout / 1000;
-      setTimeout(() => {
+      timerId = setTimeout(() => {
         proc.kill();
         reject(
           `Timeout; It took longer than ${timeoutSeconds}s to generate the call graph.`,
@@ -37,6 +38,9 @@ export function execute(
     });
 
     proc.on('close', (code: number) => {
+      if (timerId !== null) {
+        clearTimeout(timerId);
+      }
       if (code !== 0) {
         return reject(stdout || stderr);
       }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Clear the timeout meant to kill an external process, if the process exists before timeout elapses.