### PR TITLE
feat: use --dirs-to-get-entrypoints to call-graph-generator

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,4 @@
 {
-  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.1.1-jar-with-dependencies.jar",
-  "CALL_GRAPH_GENERATOR_CHECKSUM": "abfcace534f9b374469d488d8a7ef01dd10480ea5c896f539952d4295660124d"
+  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.2.0-jar-with-dependencies.jar",
+  "CALL_GRAPH_GENERATOR_CHECKSUM": "4d1810aa968f8b44b0ce9d5fbe88796ff51eabdd9f15995279ed32d7fc7cce32"
 }

--- a/test/lib/java-wrapper.test.ts
+++ b/test/lib/java-wrapper.test.ts
@@ -1,9 +1,5 @@
 import * as path from 'path';
-import {
-  getClassPerJarMapping,
-  getEntrypoints,
-  getCallGraph,
-} from '../../lib/java-wrapper';
+import { getClassPerJarMapping, getTargets } from '../../lib/java-wrapper';
 
 test('classes per jar mapping is created', async () => {
   const mapping = await getClassPerJarMapping(
@@ -21,37 +17,6 @@ test('classes per jar mapping is created', async () => {
 
 test('not target folder throw error', async () => {
   expect(
-    getEntrypoints('some-bogus-folder-that-does-not-exist'),
+    getTargets('some-bogus-folder-that-does-not-exist'),
   ).rejects.toThrowError('Could not find a target folder');
-});
-
-test('entrypoints are found correctly', async () => {
-  const expectedEntrypoints = [
-    'io/github/todolist/core/domain/Priority',
-    'io/github/todolist/core/domain/Todo',
-    'io/github/todolist/core/domain/User',
-    'io/github/todolist/core/repository/api/TodoRepository',
-    'io/github/todolist/core/repository/api/UserRepository',
-    'io/github/todolist/core/repository/impl/TodoRepositoryImpl',
-    'io/github/todolist/core/repository/impl/UserRepositoryImpl',
-    'io/github/todolist/core/service/api/TodoService',
-    'io/github/todolist/core/service/api/UserService',
-    'io/github/todolist/core/service/impl/TodoServiceImpl',
-    'io/github/todolist/core/service/impl/UserServiceImpl',
-  ];
-  expect(
-    await getEntrypoints(
-      path.join(__dirname, '../fixtures/example-java-project'),
-    ),
-  ).toStrictEqual(expectedEntrypoints);
-});
-
-test('getCallGraph throws if cannot find entry points', async () => {
-  const noEntrypointsTargetFolder = path.join(
-    __dirname,
-    '../fixtures/java-project-no-entrypoints',
-  );
-  expect(
-    getCallGraph('some-class-paths', noEntrypointsTargetFolder),
-  ).rejects.toThrowError('No entrypoints found');
 });


### PR DESCRIPTION


- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bumps `java-call-graph-generator` and start using `--dirs-to-get-entrypoints` instead of `--classes-to-get-entrypoints`

This will fix some problems that are happening about commands being too long
