### PR TITLE
fix: show correct error for gradle when target folder is missing

### DIFF
--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -32,12 +32,19 @@ export class EmptyClassPathError extends Error {
 }
 
 export class MissingTargetFolderError extends Error {
-  public readonly userMessage =
-    "Could not find the project's target folder. Please compile your code by running `mvn compile` and try again.";
+  public readonly userMessage: string;
+  errorMessagePerPackageManager = {
+    mvn:
+      "Could not find the project's target folder. Please compile your code by running `mvn compile` and try again.",
+    gradle:
+      "Could not find the project's target folder. Please compile your code and try again.",
+  };
 
-  constructor(targetPath: string) {
+  constructor(targetPath: string, packageManager: 'mvn' | 'gradle') {
     super(`Could not find the target folder starting in "${targetPath}"`);
     Object.setPrototypeOf(this, MissingTargetFolderError.prototype);
+
+    this.userMessage = this.errorMessagePerPackageManager[packageManager];
   }
 }
 

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -63,7 +63,7 @@ export async function getTargets(
     ),
   );
   if (!targetDirs.length) {
-    throw new MissingTargetFolderError(targetPath);
+    throw new MissingTargetFolderError(targetPath, packageManager);
   }
 
   return targetDirs;

--- a/test/lib/index.test.ts
+++ b/test/lib/index.test.ts
@@ -1,9 +1,21 @@
 import { getTargets } from '../../lib/index';
+import { MissingTargetFolderError } from '../../lib/errors';
 
-test('not target folder throw error', async () => {
-  expect(
-    getTargets('some-bogus-folder-that-does-not-exist', 'mvn'),
-  ).rejects.toThrowError(
-    'Could not find the target folder starting in "some-bogus-folder-that-does-not-exist"',
+test('get targets - maven - no target folder throws and error', async () => {
+  const targetPath = 'some-bogus-folder-that-does-not-exist';
+  const expectedError = new MissingTargetFolderError(targetPath, 'mvn');
+  expect(getTargets(targetPath, 'mvn')).rejects.toEqual(expectedError);
+  expect(expectedError.userMessage).toEqual(
+    "Could not find the project's target folder. Please compile your code by running `mvn compile` and try again.",
+  );
+});
+
+test('get targets - gradle - no target folder throws an error', async () => {
+  const targetPath = 'some-bogus-folder-that-does-not-exist';
+  const expectedError = new MissingTargetFolderError(targetPath, 'gradle');
+
+  expect(getTargets(targetPath, 'gradle')).rejects.toEqual(expectedError);
+  expect(expectedError.userMessage).toEqual(
+    "Could not find the project's target folder. Please compile your code and try again.",
   );
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

show correct error for Gradle when the target folder is missing.

We used to include a suggestion to run `mvn compile` for Gradle, this should
be omitted.

### More information

- [Jira ticket FLOW-443](https://snyksec.atlassian.net/browse/FLOW-443)
- [Link to documentation](https://github.com/snyk/composer-license-collector/wiki/)

### Screenshots

![image](https://user-images.githubusercontent.com/5316748/95011572-4e82d900-063a-11eb-92b6-697f9ef0e2ed.png)

