### PR TITLE
feat: print stacktrace in addition to error message

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,4 @@
 {
-  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.3.1-jar-with-dependencies.jar",
-  "CALL_GRAPH_GENERATOR_CHECKSUM": "cb52d225113727df15346e0b29fb81b3e38fee88e1f6fa8db55efc5f19d62977"
+  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.4.0-jar-with-dependencies.jar",
+  "CALL_GRAPH_GENERATOR_CHECKSUM": "b049ad13d495584ce77fabb24d87978c32c14862e4b91079136d224b66557d99"
 }

--- a/lib/errors.ts
+++ b/lib/errors.ts
@@ -54,8 +54,17 @@ export class SubprocessTimeoutError extends Error {
 }
 
 export class SubprocessError extends Error {
-  constructor(command: string, args: string, exitCode: number) {
-    super(`The command "${command} ${args}" exited with code ${exitCode}`);
+  constructor(
+    command: string,
+    args: string,
+    exitCode: number,
+    stdError?: string,
+  ) {
+    super(
+      `The command "${command} ${args}" exited with code ${exitCode}${
+        stdError ? ', Standard Error Output: ' + stdError : ''
+      }`,
+    );
     Object.setPrototypeOf(this, SubprocessError.prototype);
   }
 }

--- a/lib/sub-process.ts
+++ b/lib/sub-process.ts
@@ -48,7 +48,17 @@ export function execute(
         clearTimeout(timerId);
       }
       if (code !== 0) {
-        const err = new SubprocessError(command, args.join(' '), code);
+        const trimmedStackTrace = stderr
+          .replace(/\t/g, '')
+          .split('\n')
+          .slice(0, 5)
+          .join(', ');
+        const err = new SubprocessError(
+          command,
+          args.join(' '),
+          code,
+          trimmedStackTrace,
+        );
         debug(err.message);
         return reject(err);
       }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

The subprocess calling the Java call graph generator was not adding the
stack trace and we were missing out on important information from the
call graph generator in our logging facilities. Due to our internal
logging tools trimming the size of our messages, we publish up to 5 frames
of the stack trace to our logs.

### More information

- [Jira ticket SC-398](https://snyksec.atlassian.net/browse/SC-398)

### Screenshots

![image](https://user-images.githubusercontent.com/11861490/95017688-84888300-0663-11eb-80c7-2f8ae090cf53.png)

