### PR TITLE
fix: clear download progress bar once finished

### DIFF
--- a/lib/fetch-snyk-java-call-graph-generator.ts
+++ b/lib/fetch-snyk-java-call-graph-generator.ts
@@ -24,6 +24,7 @@ function createProgressBar(total: number, name: string): ProgressBar {
       incomplete: '.',
       width: 20,
       total: total / 1000,
+      clear: true,
     },
   );
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Clear the progress bar once finish, this is helpful when trying to parse the results as JSON.

