### PR TITLE
fix: support getting maven classpath for windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,9 @@ It is an internal component intended for use by our [CLI maven plugin](https://g
 
 | OS     |  Supported |
 |--------|------------|
-| Linux  | ✅          |
-| OSX    | ️✅          |
+| Linux  |  ✅        |
+| OSX    | ️✅        |
+| Windows| ️✅        |
 
 ## Supported Node versions
 

--- a/lib/mvn-wrapper.ts
+++ b/lib/mvn-wrapper.ts
@@ -2,16 +2,26 @@ import 'source-map-support/register';
 import { execute } from './sub-process';
 import { ClassPathGenerationError, EmptyClassPathError } from './errors';
 
-function getMvnCommandArgsForMvnExec(targetPath: string): string[] {
-  return [
-    '-q',
-    'exec:exec',
-    '-Dexec.classpathScope="compile"',
-    '-Dexec.executable="echo"',
-    '-Dexec.args="%classpath"',
-    '-f',
-    targetPath,
-  ];
+export function getMvnCommandArgsForMvnExec(targetPath: string): string[] {
+  return process.platform === 'win32'
+    ? [
+        '-q',
+        'exec:exec',
+        '-Dexec.classpathScope="compile"',
+        '-Dexec.executable="cmd"',
+        '-Dexec.args="/c echo %classpath"',
+        '-f',
+        targetPath,
+      ]
+    : [
+        '-q',
+        'exec:exec',
+        '-Dexec.classpathScope="compile"',
+        '-Dexec.executable="echo"',
+        '-Dexec.args="%classpath"',
+        '-f',
+        targetPath,
+      ];
 }
 
 function getMvnCommandArgsForDependencyPlugin(targetPath: string): string[] {

--- a/test/lib/mvn-wrapper.test.ts
+++ b/test/lib/mvn-wrapper.test.ts
@@ -2,6 +2,7 @@ import {
   parseMvnDependencyPluginCommandOutput,
   mergeMvnClassPaths,
   parseMvnExecCommandOutput,
+  getMvnCommandArgsForMvnExec,
 } from '../../lib/mvn-wrapper';
 
 import * as fs from 'fs';
@@ -48,4 +49,29 @@ test('merging mvn class paths', async () => {
   expect(mergeMvnClassPaths(dependencyPluginClassPaths)).toEqual(
     mergedClassPath,
   );
+});
+
+test('getMvnCommandArgsForMvnExec - gets the right mvn commands', () => {
+  const targetPath = 'pathToClasspath';
+  if (process.platform === 'win32') {
+    expect(getMvnCommandArgsForMvnExec(targetPath)).toEqual([
+      '-q',
+      'exec:exec',
+      '-Dexec.classpathScope="compile"',
+      '-Dexec.executable="cmd"',
+      '-Dexec.args="/c echo %classpath"',
+      '-f',
+      targetPath,
+    ]);
+  } else {
+    expect(getMvnCommandArgsForMvnExec(targetPath)).toEqual([
+      '-q',
+      'exec:exec',
+      '-Dexec.classpathScope="compile"',
+      '-Dexec.executable="echo"',
+      '-Dexec.args="%classpath"',
+      '-f',
+      targetPath,
+    ]);
+  }
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does
Support getting maven classpath for windows
Windows don't support using `echo` out of the box, there is a need to pass it with through `cmd`.

### More information

- [Jira ticket FLOW-406](https://snyksec.atlassian.net/browse/FLOW-406)
