### PR TITLE
fix: use snyk-config version v4.0.0-rc.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jszip": "^3.2.2",
     "needle": "^2.3.3",
     "progress": "^2.0.3",
-    "snyk-config": "^3.0.0",
+    "snyk-config": "^4.0.0-rc.2",
     "source-map-support": "^0.5.7",
     "temp-dir": "^2.0.0",
     "tslib": "^1.9.3"


### PR DESCRIPTION
Updates to the new snyk-config version that should get shipped with the CLI first.

Requirement for https://github.com/snyk/snyk/pull/1524
Follow up to the https://github.com/snyk/config/pull/43