### PR TITLE
fix: handle long classpaths

### DIFF
--- a/lib/mvn-wrapper.ts
+++ b/lib/mvn-wrapper.ts
@@ -1,7 +1,82 @@
 import 'source-map-support/register';
 import { execute } from './sub-process';
 import { ClassPathGenerationError, EmptyClassPathError } from './errors';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as tmp from 'tmp';
+import { debug } from './debug';
 
+async function runCommandWithOutputToFile(
+  f: (string) => Promise<void>,
+): Promise<string> {
+  // NOTE(alexmu): We have to do this little dance with output written to files
+  // because that seems to be the only way to get the output without having to
+  // parse maven logs
+  const outputFile = tmp.tmpNameSync();
+  try {
+    await f(outputFile);
+    return fs.readFileSync(outputFile, 'utf8');
+  } finally {
+    fs.unlinkSync(outputFile);
+  }
+}
+
+async function getDependenciesClassPath(targetPath: string): Promise<string> {
+  return runCommandWithOutputToFile(async (outputFile) => {
+    await execute(
+      'mvn',
+      [
+        'dependency:build-classpath',
+        `-Dmdep.outputFile=${outputFile}`,
+        '-f',
+        targetPath,
+      ],
+      { cwd: targetPath },
+    );
+  });
+}
+
+async function getOutputDirectory(targetPath: string): Promise<string> {
+  return runCommandWithOutputToFile(async (outputFile) => {
+    await execute(
+      'mvn',
+      [
+        'help:evaluate',
+        '-Dexpression="project.build.outputDirectory"',
+        `-Doutput=${outputFile}`,
+        '-f',
+        targetPath,
+      ],
+      { cwd: targetPath },
+    );
+  });
+}
+
+export function buildFullClassPath(
+  dependenciesClassPath: string,
+  outputDirectory: string,
+): string {
+  if (dependenciesClassPath.length === 0) {
+    debug('Failed to determine the dependencies classpath.');
+  }
+  if (outputDirectory.length === 0) {
+    debug('Failed to determine the project output directory.');
+  }
+  const sanitisedOutputDirectory = outputDirectory.trim();
+  let sanitisedClassPath = dependenciesClassPath.trim();
+  while (sanitisedClassPath.endsWith(path.delimiter)) {
+    sanitisedClassPath = sanitisedClassPath.slice(0, -1);
+  }
+  if (sanitisedClassPath.length === 0) {
+    return sanitisedOutputDirectory;
+  } else if (sanitisedOutputDirectory.length === 0) {
+    return sanitisedClassPath;
+  } else {
+    return `${sanitisedClassPath}${path.delimiter}${sanitisedOutputDirectory}`;
+  }
+}
+
+// NOTE(alexmu): This is deprecated, and will be removed in the future
 export function getMvnCommandArgsForMvnExec(targetPath: string): string[] {
   return process.platform === 'win32'
     ? [
@@ -24,10 +99,12 @@ export function getMvnCommandArgsForMvnExec(targetPath: string): string[] {
       ];
 }
 
+// NOTE(alexmu): This is deprecated, and will be removed in the future
 function getMvnCommandArgsForDependencyPlugin(targetPath: string): string[] {
   return ['dependency:build-classpath', '-f', targetPath];
 }
 
+// NOTE(alexmu): This is deprecated, and will be removed in the future
 export function parseMvnDependencyPluginCommandOutput(
   mvnCommandOutput: string,
 ): string[] {
@@ -46,10 +123,12 @@ export function parseMvnDependencyPluginCommandOutput(
   return mvnClassPaths;
 }
 
+// NOTE(alexmu): This is deprecated, and will be removed in the future
 export function parseMvnExecCommandOutput(mvnCommandOutput: string): string[] {
   return mvnCommandOutput.trim().split('\n');
 }
 
+// NOTE(alexmu): This is deprecated, and will be removed in the future
 export function mergeMvnClassPaths(classPaths: string[]): string {
   // this magic joins all items in array with :, splits result by : again
   // makes Set (to uniq items), create Array from it and join it by : to have
@@ -57,7 +136,8 @@ export function mergeMvnClassPaths(classPaths: string[]): string {
   return Array.from(new Set(classPaths.join(':').split(':'))).join(':');
 }
 
-export async function getClassPathFromMvn(targetPath: string): Promise<string> {
+// NOTE(alexmu): This is deprecated, and will be removed in the future
+async function getClassPathFromMvnLegacy(targetPath: string): Promise<string> {
   let classPaths: string[] = [];
   let args: string[] = [];
   try {
@@ -81,4 +161,27 @@ export async function getClassPathFromMvn(targetPath: string): Promise<string> {
     throw new EmptyClassPathError(`mvn ${args.join(' ')}`);
   }
   return mergeMvnClassPaths(classPaths);
+}
+
+export async function getClassPathFromMvn(targetPath: string): Promise<string> {
+  try {
+    const [dependenciesClassPath, outputDirectory] = await Promise.all([
+      getDependenciesClassPath(targetPath),
+      getOutputDirectory(targetPath),
+    ]);
+    const fullClassPath = buildFullClassPath(
+      dependenciesClassPath,
+      outputDirectory,
+    );
+    if (fullClassPath.length === 0) {
+      throw new EmptyClassPathError('mvn');
+    }
+    return fullClassPath;
+  } catch (e) {
+    // NOTE(alexmu): Fall back to the legacy method of determining the classpath
+    debug(
+      `Failed to determine the classpath using the new method. Falling back to the legacy method. ${e}`,
+    );
+    return getClassPathFromMvnLegacy(targetPath);
+  }
 }

--- a/test/lib/mvn-wrapper.test.ts
+++ b/test/lib/mvn-wrapper.test.ts
@@ -3,6 +3,7 @@ import {
   mergeMvnClassPaths,
   parseMvnExecCommandOutput,
   getMvnCommandArgsForMvnExec,
+  buildFullClassPath,
 } from '../../lib/mvn-wrapper';
 
 import * as fs from 'fs';
@@ -74,4 +75,25 @@ test('getMvnCommandArgsForMvnExec - gets the right mvn commands', () => {
       targetPath,
     ]);
   }
+});
+
+test('buildFullClassPath', () => {
+  function buildPath(entries: string[]): string {
+    return entries.join(path.delimiter);
+  }
+
+  expect(buildFullClassPath(buildPath(['aaa', 'bbb']), 'ccc')).toEqual(
+    buildPath(['aaa', 'bbb', 'ccc']),
+  );
+  expect(buildFullClassPath('aaa', 'bbb')).toEqual(buildPath(['aaa', 'bbb']));
+  expect(buildFullClassPath('aaa', '')).toEqual('aaa');
+  expect(buildFullClassPath('', 'aaa')).toEqual('aaa');
+  expect(buildFullClassPath(`aaa${path.delimiter}`, '')).toEqual('aaa');
+  expect(buildFullClassPath(`aaa${path.delimiter}`, 'bbb')).toEqual(
+    buildPath(['aaa', 'bbb']),
+  );
+  expect(
+    buildFullClassPath(`aaa${path.delimiter}${path.delimiter}`, 'bbb'),
+  ).toEqual(buildPath(['aaa', 'bbb']));
+  expect(buildFullClassPath('', '')).toEqual('');
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

This change set updates the maven wrapper to use only plugins for determining the classpath we pass to the call graph builder. It uses `dependency:build-classpath` to get the classpath for the dependencies. Sadly, that doesn't include the output directory (I tried to set the scope to `compile`, but I couldn't get it to add the output directory to the classpath it gives back). To work around this, it uses `help:evaluate` to get `project.build.outputDirectory`, and append it to the classpath manually.

This has a few advantages:
- it's not limited by the maximum length of the command line on any given platform;
- it doesn't have to parse maven output;

and a few shortcomings:
- it needs to use temporary files because I couldn't find a way to make maven not produce logs;
- it needs an extra plugin [`maven-help`](https://maven.apache.org/plugins/maven-help-plugin/index.html), *but* that seems to be available without having to add it to the POM file.

It's been tested on macOS and Windows, and it gives the same results as the current approach.

For context: https://snyk.slack.com/archives/C07N668DA/p1605690001356600

### Notes for the reviewer

I've opted to keep the current method as a fallback. We'll remove it when we can confirm this works in the wild.

### More information

- [Jira ticket FLOW-487](https://snyksec.atlassian.net/browse/FLOW-487)