### PR TITLE
fix: add missing tmp dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,16 +33,17 @@
   ],
   "homepage": "https://github.com/snyk/java-call-graph-builder#readme",
   "dependencies": {
-    "graphlib": "^2.1.8",
     "ci-info": "^2.0.0",
     "debug": "^4.1.1",
     "glob": "^7.1.6",
+    "graphlib": "^2.1.8",
     "jszip": "^3.2.2",
     "needle": "^2.3.3",
     "progress": "^2.0.3",
     "snyk-config": "^4.0.0-rc.2",
     "source-map-support": "^0.5.7",
     "temp-dir": "^2.0.0",
+    "tmp": "^0.2.1",
     "tslib": "^1.9.3"
   },
   "devDependencies": {


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Add missing `tmp` dependency.

This worked previously because the dependenc was pulled in by the `snyk` CLI. Pushing dependencies down, close to thier use site.