### PR TITLE
feat: support `gradlew` for gradle sub projects

### DIFF
--- a/lib/gradle-wrapper.ts
+++ b/lib/gradle-wrapper.ts
@@ -1,7 +1,6 @@
 import 'source-map-support/register';
 import { execute } from './sub-process';
 import * as path from 'path';
-import * as fs from 'fs';
 import { ClassPathGenerationError } from './errors';
 
 export function getGradleCommandArgs(targetPath: string): string[] {
@@ -18,23 +17,13 @@ export function getGradleCommandArgs(targetPath: string): string[] {
   return gradleArgs;
 }
 
-export function getGradleCommand(targetPath: string): string {
-  const pathToWrapper = path.resolve(targetPath || '', '.', 'gradlew');
-
-  if (fs.existsSync(pathToWrapper)) {
-    return pathToWrapper;
-  }
-
-  return 'gradle';
-}
-
 export async function getClassPathFromGradle(
   targetPath: string,
+  gradlePath: string,
 ): Promise<string> {
-  const cmd = getGradleCommand(targetPath);
   const args = getGradleCommandArgs(targetPath);
   try {
-    const output = await execute(cmd, args, { cwd: targetPath });
+    const output = await execute(gradlePath, args, { cwd: targetPath });
     return output.trim();
   } catch (e) {
     console.log(e);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -60,10 +60,13 @@ export async function getCallGraphMvn(
 
 export async function getCallGraphGradle(
   targetPath: string,
+  gradlePath = 'gradle',
   timeout?: number,
 ): Promise<Graph> {
   const [classPath, targets] = await Promise.all([
-    timeIt('getGradleClassPath', () => getClassPathFromGradle(targetPath)),
+    timeIt('getGradleClassPath', () =>
+      getClassPathFromGradle(targetPath, gradlePath),
+    ),
     timeIt('getEntrypoints', () => findBuildDirs(targetPath, 'gradle')),
   ]);
 

--- a/test/integration/e2e-run_gradle.test.ts
+++ b/test/integration/e2e-run_gradle.test.ts
@@ -1,6 +1,5 @@
 import * as path from 'path';
 import * as fs from '../../lib/promisified-fs-glob';
-import * as os from 'os';
 import { getCallGraphGradle } from '../../lib';
 
 jest.setTimeout(60000);
@@ -15,6 +14,7 @@ test('callgraph for gradle is created', async () => {
       __dirname,
       ...'../fixtures/java-reachability-playground'.split('/'),
     ),
+    'gradle',
   );
 
   // verify tempdir was created and file written


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

For gradle sub projects the `gradlew` util is defined on the root folder of the project.
Today we are trying to get the `gradlew` util only from the target path of the gradle project and missing scripts that are on the root folder of the project.

This change takes the gradle util as a parameter from the gradle plugin, which gives the benefit of having it also deal with windows.

### More information

- [Jira ticket FLOW-564](https://snyksec.atlassian.net/browse/FLOW-564)
