### PR TITLE
feat: improve gradle and android reachability generation

### DIFF
--- a/bin/init.gradle
+++ b/bin/init.gradle
@@ -1,8 +1,52 @@
 allprojects { everyProj ->
-  task printClasspath {
-        doFirst {
-            apply plugin: 'java'
-            println(sourceSets.main.runtimeClasspath.asPath)
+
+    task printClasspath {
+        doLast {
+            def classPath = [].toSet();
+
+            pluginManager.withPlugin('java') {
+                classPath = sourceSets.main.runtimeClasspath.asPath
+            }
+
+            if (!classPath) {
+                pluginManager.withPlugin('android') {
+                    def androidBootClasspath = android.getBootClasspath()[0]
+                    def cp = [androidBootClasspath];
+
+                    project.android.applicationVariants.all { v ->
+                        v.getCompileClasspath(null).getFiles().each {
+                            File f ->
+                                cp.add(f.getAbsolutePath())
+                        }
+                        v.javaCompile.classpath.getFiles().each {
+                            f -> cp.add(f)
+                        }
+
+                        cp.add(v.javaCompile.destinationDir.getAbsolutePath())
+                    }
+                    classPath = cp.join(":")
+                }
+            }
+
+            /*
+            the `snykReachabilityClasspath` can be declared using a `ext` block
+            in the projects build script
+
+            e.g for java:
+
+            ext {
+                snykReachabilityClasspath = sourceSets.main.compileClasspath.asPath
+            }
+
+            It requires a path formatted string, e.g:
+
+
+             */
+            if (!classPath && project.hasProperty('snykReachabilityClasspath')) {
+                classPath = project.snykReachabilityClasspath
+            }
+
+            if (classPath) println(classPath)
         }
     }
-  }
+}

--- a/config.default.json
+++ b/config.default.json
@@ -1,4 +1,4 @@
 {
-  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.4.0-jar-with-dependencies.jar",
-  "CALL_GRAPH_GENERATOR_CHECKSUM": "b049ad13d495584ce77fabb24d87978c32c14862e4b91079136d224b66557d99"
+  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.5.0-jar-with-dependencies.jar",
+  "CALL_GRAPH_GENERATOR_CHECKSUM": "b83fbc47e3dc668e7b8ad53a81d69fecdcb9e032f5eefa0def49036ac5939417"
 }

--- a/lib/gradle-wrapper.ts
+++ b/lib/gradle-wrapper.ts
@@ -2,6 +2,7 @@ import 'source-map-support/register';
 import { execute } from './sub-process';
 import * as path from 'path';
 import { ClassPathGenerationError } from './errors';
+import { EOL } from 'os';
 
 export function getGradleCommandArgs(targetPath: string): string[] {
   const gradleArgs = [
@@ -24,7 +25,10 @@ export async function getClassPathFromGradle(
   const args = getGradleCommandArgs(targetPath);
   try {
     const output = await execute(gradlePath, args, { cwd: targetPath });
-    return output.trim();
+    const lines = output.trim().split(EOL);
+    const lastLine = lines[lines.length - 1];
+
+    return lastLine.trim();
   } catch (e) {
     console.log(e);
     throw new ClassPathGenerationError(e);


### PR DESCRIPTION
This PR does the following:

- It updates java-call-graph-generator to 1.5.0 so that it better parse classnames and be able to support android projects
- Improved the `init.gradle` script to support android, and also custom defined classpath.

The reasoning behind the changes on `init.gradle` are that importing the `java` plugin can cause conflicts with existing tasks as seen in https://github.com/snyk/java-call-graph-builder/issues/43 now it checks which plugins are used and takes the best approach (currently only java and android.

Also it adds a extension point so that the user can specify a custom classpath by creating a ext property named `snykReachabilityCallgraph`