### PR TITLE
Feat/gradle config attributes classpath filter

### DIFF
--- a/bin/init.gradle
+++ b/bin/init.gradle
@@ -24,6 +24,14 @@ allprojects { everyProj ->
 
                         cp.add(v.javaCompile.destinationDir.getAbsolutePath())
                     }
+
+                    // apply config-attributes in classpath recovery
+                    if (project.hasProperty('confAttrs')) {
+                        def confAttrSpec = confAttrs.toLowerCase().split(',').collectEntries { [(it.split(':')[0]) : it.split(':')[1]] }
+
+                        cp.unique().removeIf { (it.toLowerCase() ==~ /.*${confAttrSpec['backend']}(?!.*${confAttrSpec['buildtype']}).*/) }
+                    }
+                    
                     classPath = cp.join(":")
                 }
             }

--- a/bin/init.gradle
+++ b/bin/init.gradle
@@ -13,7 +13,29 @@ allprojects { everyProj ->
                     def androidBootClasspath = android.getBootClasspath()[0]
                     def cp = [androidBootClasspath];
 
+                    def confAttrSpec = [:]
+                    def configuredDimensionList = []
+                    if (project.hasProperty('confAttrs')) {
+                        confAttrSpec = confAttrs.toLowerCase().split(',').collectEntries { [(it.split(':')[0]) : it.split(':')[1]] }
+                        configuredDimensionList = android.flavorDimensionList.findAll { confAttrSpec[it] }
+                    }
+
                     project.android.applicationVariants.all { v ->
+                        // remove classpath for unused buildTypes
+                        if (confAttrSpec['buildtype'] && v.buildType.getName() != confAttrSpec['buildtype']) {
+                           return
+                        }
+
+                        // remove classpath for unused dimensions
+                        if (configuredDimensionList) {
+                          def usedFlavors = configuredDimensionList.findAll {
+                             v.flavorName.toLowerCase() == confAttrSpec[it]
+                          }
+                          if (!usedFlavors) {
+                              return;
+                          }
+                        }
+
                         v.getCompileClasspath(null).getFiles().each {
                             File f ->
                                 cp.add(f.getAbsolutePath())
@@ -24,14 +46,6 @@ allprojects { everyProj ->
 
                         cp.add(v.javaCompile.destinationDir.getAbsolutePath())
                     }
-
-                    // apply config-attributes in classpath recovery
-                    if (project.hasProperty('confAttrs')) {
-                        def confAttrSpec = confAttrs.toLowerCase().split(',').collectEntries { [(it.split(':')[0]) : it.split(':')[1]] }
-
-                        cp.unique().removeIf { (it.toLowerCase() ==~ /.*${confAttrSpec['backend']}(?!.*${confAttrSpec['buildtype']}).*/) }
-                    }
-                    
                     classPath = cp.join(":")
                 }
             }

--- a/lib/gradle-wrapper.ts
+++ b/lib/gradle-wrapper.ts
@@ -1,12 +1,13 @@
 import 'source-map-support/register';
 import { execute } from './sub-process';
 import * as path from 'path';
+import { EOL, platform } from 'os';
 import { ClassPathGenerationError } from './errors';
-import { EOL } from 'os';
 
 export function getGradleCommandArgs(
   targetPath: string,
   initScript?: string,
+  confAttrs?: string,
 ): string[] {
   const gradleArgs = [
     'printClasspath',
@@ -20,6 +21,12 @@ export function getGradleCommandArgs(
   if (initScript) {
     gradleArgs.push('--init-script', initScript);
   }
+  if (confAttrs) {
+    const isWin = /^win/.test(platform());
+    const quot = isWin ? '"' : "'";
+
+    gradleArgs.push(`-PconfAttrs=${quot}${confAttrs}${quot}`);
+  }
 
   return gradleArgs;
 }
@@ -28,8 +35,9 @@ export async function getClassPathFromGradle(
   targetPath: string,
   gradlePath: string,
   initScript?: string,
+  confAttrs?: string,
 ): Promise<string> {
-  const args = getGradleCommandArgs(targetPath, initScript);
+  const args = getGradleCommandArgs(targetPath, initScript, confAttrs);
   try {
     const output = await execute(gradlePath, args, { cwd: targetPath });
     const lines = output.trim().split(EOL);

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -62,11 +62,12 @@ export async function getCallGraphGradle(
   targetPath: string,
   gradlePath = 'gradle',
   initScript?: string,
+  confAttrs?: string,
   timeout?: number,
 ): Promise<Graph> {
   const [classPath, targets] = await Promise.all([
     timeIt('getGradleClassPath', () =>
-      getClassPathFromGradle(targetPath, gradlePath, initScript),
+      getClassPathFromGradle(targetPath, gradlePath, initScript, confAttrs),
     ),
     timeIt('getEntrypoints', () => findBuildDirs(targetPath, 'gradle')),
   ]);

--- a/test/lib/gradle-wrapper.test.ts
+++ b/test/lib/gradle-wrapper.test.ts
@@ -1,6 +1,7 @@
 import { getGradleCommandArgs } from '../../lib/gradle-wrapper';
 
 import * as path from 'path';
+import { platform } from 'os';
 
 test('get right args for gradle command', async () => {
   expect(
@@ -25,5 +26,26 @@ test('get right args for gradle command without init script', async () => {
     '-q',
     '-p',
     'directory_name',
+  ]);
+});
+
+test('get right args for gradle command with configuration attributes', async () => {
+  const isWin = /^win/.test(platform());
+  const quot = isWin ? '"' : "'";
+
+  expect(
+    getGradleCommandArgs(
+      'directory_name',
+      undefined,
+      'buildtype:release,usage:java-runtime,backend:prod',
+    ),
+  ).toEqual([
+    'printClasspath',
+    '-I',
+    path.join(__dirname, '../../bin/init.gradle'),
+    '-q',
+    '-p',
+    'directory_name',
+    `-PconfAttrs=${quot}buildtype:release,usage:java-runtime,backend:prod${quot}`,
   ]);
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [x] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

An error occurred while generating the call-graph. The main reason behind the error is the lack of a proper filtering on the build flavor that is explicitly specified in `configuration-attributes` gradle options.  

### Notes for the reviewer

#### PR for #9512 - filter classpath based on config attributes  
Snyk reachability produces a call-graph which simply contains call-hierarchy of different modules used in the code. java-call-graph-builder prints classpath of project (sub-project) using printClassPath task declared in [`init.gradle`](https://github.com/snyk/java-call-graph-builder/blob/master/bin/init.gradle). Generated classpath is passed to [`java-call-graph-generator.jar`](https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.5.0-jar-with-dependencies.jar) to generate call-graphs from classes. Here is the location this error happens:  

`
java -cp ./call-graph-generator/java-call-graph-generator.jar io.snyk.callgraph.app.App --application-classpath-file ./call-graph-generatorFqHSLD/callgraph-classpath --dirs-to-get-entrypoints ./varo-bank/mobile/android/varo-bank-android/app/build
`  

`callgraph-classpath` file contains the application classpath information as string of class pathes concatenated using colon. The command we passed in this scenario to the `snyk monitor` is the following:  

```
snyk monitor --all-sub-projects --file=app/build.gradle.kts --configuration-attributes=buildtype:release,usage:java-runtime,backend:prod --debug --insecure  --severity-threshold=medium --reachable -d >> log.txt 
```

Here is the `log.txt` contents: 

```bash
Error: 
Monitoring /Users/iosbuild/builds/u_N9zkzD/0/varo-bank/mobile/android/varo-bank-android...

ENOENT: no such file or directory, open '/Users/iosbuild/builds/u_N9zkzD/0/varo-bank/mobile/android/varo-bank-android/app/build/intermediates/compile_and_runtime_not_namespaced_r_class_jar/prodPenTest/R.jar'
    at monitor (/usr/local/lib/node_modules/snyk/src/cli/commands/monitor/index.ts:297:9)
```  

After I closely looked at the classpath, I noticed that the recovered class paths includes all the other build flavors defined in the `build.gradle.kts`.  However, we explicitly mentioned `prodRelease` target in the configuration attributes passed to the monitor command. Now, it is obvious that `prodPenTest` classes are not found cause we did not compiled those at all. 

To fix this issue, I decided to propagate the `PconfAttr` variable through `getCallGraphGradle` as an argument to the `printClasspath` task. Next, if a certain build flavor specified, we can filter the ones that are not mentioned in `configuration-attributes`.  

### More information

- [Zendesk#9512](https://support.snyk.io/hc/en-us/requests/9512)
- snyk/snyk-gradle-plugin#171

### Screenshots

_Visuals that may help the reviewer_
