### PR TITLE
Feat: added support for custom maven arguments

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -16,10 +16,13 @@ tmp.setGracefulCleanup();
 export async function getCallGraphMvnLegacy(
   targetPath: string,
   timeout?: number,
+  customMavenArgs?: string[],
 ): Promise<Graph> {
   try {
     const [classPath, targets] = await Promise.all([
-      timeIt('getMvnClassPath', () => getClassPathFromMvn(targetPath)),
+      timeIt('getMvnClassPath', () =>
+        getClassPathFromMvn(targetPath, customMavenArgs),
+      ),
       timeIt('getEntrypoints', () => findBuildDirs(targetPath, 'mvn')),
     ]);
 
@@ -38,9 +41,10 @@ export async function getCallGraphMvnLegacy(
 export async function getCallGraphMvn(
   targetPath: string,
   timeout?: number,
+  customMavenArgs?: string[],
 ): Promise<Graph> {
   try {
-    const project = await makeMavenProject(targetPath);
+    const project = await makeMavenProject(targetPath, customMavenArgs);
     const classPath = project.getClassPath();
     const buildDirectories = await Promise.all(
       project.modules.map((m) => m.buildDirectory),
@@ -54,7 +58,7 @@ export async function getCallGraphMvn(
       `Failed to get the call graph for the Maven project in: ${targetPath}. ' +
       'Falling back to the legacy method.`,
     );
-    return getCallGraphMvnLegacy(targetPath, timeout);
+    return getCallGraphMvnLegacy(targetPath, timeout, customMavenArgs);
   }
 }
 

--- a/lib/mvn-wrapper-legacy.ts
+++ b/lib/mvn-wrapper-legacy.ts
@@ -65,20 +65,25 @@ export function mergeMvnClassPaths(classPaths: string[]): string {
     .join(path.delimiter);
 }
 
-export async function getClassPathFromMvn(targetPath: string): Promise<string> {
+export async function getClassPathFromMvn(
+  targetPath: string,
+  customMavenArgs: string[] = [],
+): Promise<string> {
   let classPaths: string[] = [];
   let args: string[] = [];
   try {
     try {
       // there are two ways of getting classpath - either from maven plugin or by exec command
       // try `mvn exec` for classpath
-      args = getMvnCommandArgsForMvnExec(targetPath);
+      args = getMvnCommandArgsForMvnExec(targetPath).concat(customMavenArgs);
       const output = await execute('mvn', args, { cwd: targetPath });
       classPaths = parseMvnExecCommandOutput(output);
     } catch (e) {
       // if it fails, try mvn dependency:build-classpath
       // TODO send error message for further analysis
-      args = getMvnCommandArgsForDependencyPlugin(targetPath);
+      args = getMvnCommandArgsForDependencyPlugin(targetPath).concat(
+        customMavenArgs,
+      );
       const output = await execute('mvn', args, { cwd: targetPath });
       classPaths = parseMvnDependencyPluginCommandOutput(output);
     }

--- a/test/fixtures/java-reachability-playground/settings.xml
+++ b/test/fixtures/java-reachability-playground/settings.xml
@@ -1,0 +1,12 @@
+    <settings xmlns="http://maven.apache.org/SETTINGS/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+      xsi:schemaLocation="http://maven.apache.org/SETTINGS/1.0.0 https://maven.apache.org/xsd/settings-1.0.0.xsd">
+      <localRepository/>
+      <interactiveMode/>
+      <offline/>
+      <pluginGroups/>
+      <servers/>
+      <mirrors/>
+      <proxies/>
+      <profiles/>
+      <activeProfiles/>
+    </settings>

--- a/test/integration/e2e-run_mvn.test.ts
+++ b/test/integration/e2e-run_mvn.test.ts
@@ -7,24 +7,92 @@ jest.setTimeout(60000);
 
 let tmpFilePath;
 
-test('callgraph for maven is created', async () => {
-  const mkdtempSpy = jest.spyOn(fs, 'mkdtemp');
-  const writeFileSpy = jest.spyOn(fs, 'writeFile');
-  await getCallGraphMvn(
-    path.join(
-      __dirname,
-      ...'../fixtures/java-reachability-playground'.split('/'),
-    ),
-  );
+describe('callgraph for maven', () => {
+  it('callgraph for maven is created', async () => {
+    const mkdtempSpy = jest.spyOn(fs, 'mkdtemp');
+    const writeFileSpy = jest.spyOn(fs, 'writeFile');
+    await getCallGraphMvn(
+      path.join(
+        __dirname,
+        ...'../fixtures/java-reachability-playground'.split('/'),
+      ),
+    );
 
-  // verify tempdir was created and file written
-  expect(mkdtempSpy.mock.calls.length).toEqual(1);
-  expect(writeFileSpy.mock.calls.length).toEqual(1);
-  tmpFilePath = writeFileSpy.mock.calls[0][0];
-});
+    // verify tempdir was created and file written
+    expect(mkdtempSpy.mock.calls.length).toEqual(1);
+    expect(writeFileSpy.mock.calls.length).toEqual(1);
+    tmpFilePath = writeFileSpy.mock.calls[0][0];
+  });
 
-afterAll(async () => {
-  // verify tmp file was written; deletion is not awaited in main function,
-  // therefore it is verified after it finishes
-  expect(await fs.exists(tmpFilePath)).toBeFalsy();
+  it(`callgraph for maven is created when given a file that exists`, async () => {
+    const mkdtempSpy = jest.spyOn(fs, 'mkdtemp');
+    const writeFileSpy = jest.spyOn(fs, 'writeFile');
+    await getCallGraphMvn(
+      path.join(
+        __dirname,
+        ...'../fixtures/java-reachability-playground'.split('/'),
+      ),
+      undefined,
+      ['-s=settings.xml'],
+    );
+
+    // verify tempdir was not created and file not written
+    expect(mkdtempSpy.mock.calls.length).toEqual(1);
+    expect(writeFileSpy.mock.calls.length).toEqual(1);
+    tmpFilePath = writeFileSpy.mock.calls[0][0];
+  });
+
+  it(`throws an error when given a file that doesn't exist`, async () => {
+    await expect(
+      getCallGraphMvn(
+        path.join(
+          __dirname,
+          ...'../fixtures/java-reachability-playground'.split('/'),
+        ),
+        undefined,
+        ['-s=nonexistingfile.xml'],
+      ),
+    ).rejects.toThrow();
+  });
+
+  it(`callgraph for maven is created when given an empty arr`, async () => {
+    const mkdtempSpy = jest.spyOn(fs, 'mkdtemp');
+    const writeFileSpy = jest.spyOn(fs, 'writeFile');
+    await getCallGraphMvn(
+      path.join(
+        __dirname,
+        ...'../fixtures/java-reachability-playground'.split('/'),
+      ),
+      undefined,
+      [],
+    );
+
+    // verify tempdir was created and file written
+    expect(mkdtempSpy.mock.calls.length).toEqual(1);
+    expect(writeFileSpy.mock.calls.length).toEqual(1);
+    tmpFilePath = writeFileSpy.mock.calls[0][0];
+  });
+
+  it(`throws an error when given a wrong argument`, async () => {
+    await expect(
+      getCallGraphMvn(
+        path.join(
+          __dirname,
+          ...'../fixtures/java-reachability-playground'.split('/'),
+        ),
+        undefined,
+        ['-something=settings.xml'],
+      ),
+    ).rejects.toThrow();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    // verify tmp file was written; deletion is not awaited in main function,
+    // therefore it is verified after it finishes
+    expect(await fs.exists(tmpFilePath)).toBeFalsy();
+  });
 });


### PR DESCRIPTION
- [x] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adding the capability to pass args after the double dash to the maven commands being run inside the java call graph builder.

### More information

- [Jira ticket FLOW-692](https://snyksec.atlassian.net/jira/software/projects/FLOW/boards/96?selectedIssue=FLOW-692)
