### PR TITLE
chore: change codeowners from flow to tardis

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,4 @@
 # the repo. Unless a later match takes precedence,
 #  @flow will be requested for
 # review when someone opens a pull request.
-*       @snyk/flow
+*       @snyk/tardis


### PR DESCRIPTION
### What this does

Flow no longer owns reachability.