### PR TITLE
fix: copy init.gradle to temp file and use it

### DIFF
--- a/lib/gradle-wrapper.ts
+++ b/lib/gradle-wrapper.ts
@@ -3,18 +3,20 @@ import { execute } from './sub-process';
 import * as path from 'path';
 import { EOL, platform } from 'os';
 import { ClassPathGenerationError } from './errors';
+import * as fs from 'fs';
+import * as tmp from 'tmp';
 
 export function getGradleCommandArgs(
   targetPath: string,
   initScript?: string,
   confAttrs?: string,
 ): string[] {
-  const gradleArgs = [
-    'printClasspath',
-    '-I',
-    path.join(__dirname, ...'../bin/init.gradle'.split('/')),
-    '-q',
-  ];
+  // For binary releases, the original file would be in the binary build and inaccesible
+  const originalPath = path.join(__dirname, ...'../bin/init.gradle'.split('/'));
+  const tmpFilePath = tmp.fileSync().name;
+  fs.copyFileSync(originalPath, tmpFilePath);
+
+  const gradleArgs = ['printClasspath', '-I', tmpFilePath, '-q'];
   if (targetPath) {
     gradleArgs.push('-p', targetPath);
   }

--- a/test/lib/gradle-wrapper.test.ts
+++ b/test/lib/gradle-wrapper.test.ts
@@ -4,12 +4,15 @@ import * as path from 'path';
 import { platform } from 'os';
 
 test('get right args for gradle command', async () => {
-  expect(
-    getGradleCommandArgs('directory_name', 'some_script.gradle.kts'),
-  ).toEqual([
+  const commandArgs = getGradleCommandArgs(
+    'directory_name',
+    'some_script.gradle.kts',
+  );
+  const initGradlePath = commandArgs[2]; // Contains a temporary path
+  expect(commandArgs).toEqual([
     'printClasspath',
     '-I',
-    path.join(__dirname, '../../bin/init.gradle'),
+    initGradlePath,
     '-q',
     '-p',
     'directory_name',
@@ -19,10 +22,12 @@ test('get right args for gradle command', async () => {
 });
 
 test('get right args for gradle command without init script', async () => {
-  expect(getGradleCommandArgs('directory_name')).toEqual([
+  const commandArgs = getGradleCommandArgs('directory_name');
+  const initGradlePath = commandArgs[2]; // Contains a temporary path
+  expect(commandArgs).toEqual([
     'printClasspath',
     '-I',
-    path.join(__dirname, '../../bin/init.gradle'),
+    initGradlePath,
     '-q',
     '-p',
     'directory_name',
@@ -33,16 +38,17 @@ test('get right args for gradle command with configuration attributes', async ()
   const isWin = /^win/.test(platform());
   const quot = isWin ? '"' : "'";
 
-  expect(
-    getGradleCommandArgs(
-      'directory_name',
-      undefined,
-      'buildtype:release,usage:java-runtime,backend:prod',
-    ),
-  ).toEqual([
+  const commandArgs = getGradleCommandArgs(
+    'directory_name',
+    undefined,
+    'buildtype:release,usage:java-runtime,backend:prod',
+  );
+  const initGradlePath = commandArgs[2]; // Contains a temporary path
+
+  expect(commandArgs).toEqual([
     'printClasspath',
     '-I',
-    path.join(__dirname, '../../bin/init.gradle'),
+    initGradlePath,
     '-q',
     '-p',
     'directory_name',


### PR DESCRIPTION
- [X] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [X] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [X] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Use temporary file copied to the local filesystem to ensure the seperate process that reads init.gradle can find it in binary releases.

### More information

- https://snyksec.atlassian.net/browse/HAMMER-415

