### PR TITLE
fix: bump call graph generator version

### DIFF
--- a/config.default.json
+++ b/config.default.json
@@ -1,5 +1,5 @@
 {
-  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.6.3-jar-with-dependencies.jar",
-  "CALL_GRAPH_GENERATOR_CHECKSUM": "41fb2095d63302c1c8eab7a3392185af0845b995d045156931eeb612ca173134",
+  "CALL_GRAPH_GENERATOR_URL": "https://storage.googleapis.com/snyk-java-callgraph-generator/W3jTdXePWDEk7sZmaxNxgDAPCXnzFa6AWsvgeEN7yg/callgraph-generator-1.6.4-jar-with-dependencies.jar",
+  "CALL_GRAPH_GENERATOR_CHECKSUM": "6a66f4b5b141080bfd01f42f344f7a2fbc314c93d1fa4ba8931beabadd9e38bd",
   "_COMMENT": "use sha256 to generate CALL_GRAPH_GENERATOR_CHECKSUM"
 }


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Bump call graph generator version to 1.6.4 in order to mitigate [CVE-2021-45105](https://nvd.nist.gov/vuln/detail/CVE-2021-45105)